### PR TITLE
Clean up active call rooms when calls end

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "deploy:rules:database": "node scripts/deploy-rules.js --database",
     "debug:firestore": "node scripts/debug-firestore-400.js",
     "test:calling": "node scripts/test-calling-functionality.js",
+    "test:active-call-rooms": "node scripts/test-active-call-rooms.js",
     "create-sounds": "node scripts/create-sound-files.js",
     "render:env": "node scripts/generate-render-env.js",
     "type-check": "tsc --noEmit",

--- a/scripts/test-active-call-rooms.js
+++ b/scripts/test-active-call-rooms.js
@@ -1,0 +1,44 @@
+#!/usr/bin/env node
+
+process.env.TEST_MODE = '1';
+const { serverReady, activeCallRooms } = require('../server');
+const ioClient = require('socket.io-client');
+
+const port = process.env.PORT || 3000;
+const url = `http://localhost:${port}`;
+
+(async () => {
+  const { server } = await serverReady;
+
+  const client1 = ioClient(url);
+  const client2 = ioClient(url);
+
+  await Promise.all([
+    new Promise(resolve => client1.on('connect', resolve)),
+    new Promise(resolve => client2.on('connect', resolve))
+  ]);
+
+  client1.emit('register-user', { userId: 'user1', userName: 'User One' });
+  client2.emit('register-user', { userId: 'user2', userName: 'User Two' });
+
+  client1.emit('call-user', { targetUserId: 'user2', offer: 'fake', callerName: 'User One' });
+  client2.emit('call-answer', { callerSocketId: client1.id, answer: 'fake-answer' });
+
+  await new Promise(r => setTimeout(r, 500));
+  console.log('Active rooms after answer:', activeCallRooms.size);
+
+  client1.emit('call-end', { targetSocketId: client2.id });
+
+  await new Promise(r => setTimeout(r, 500));
+  console.log('Active rooms after end:', activeCallRooms.size);
+
+  if (activeCallRooms.size === 0) {
+    console.log('✅ activeCallRooms cleared after call end');
+  } else {
+    console.log('❌ activeCallRooms not cleared');
+  }
+
+  client1.close();
+  client2.close();
+  server.close(() => process.exit(0));
+})();


### PR DESCRIPTION
## Summary
- Track active call rooms and assign participants on call acceptance
- Remove users and room entry when a call ends, forcing the terminating socket to leave
- Add test script to exercise call room cleanup

## Testing
- `node scripts/test-active-call-rooms.js` *(fails: Cannot find module 'socket.io')*
- `npm install socket.io socket.io-client` *(fails: 403 Forbidden - GET https://registry.npmjs.org/socket.io)*

------
https://chatgpt.com/codex/tasks/task_e_6897e8e6502883309456f4ef7c821407